### PR TITLE
13.Issue - Video preview after ending and calling back with video

### DIFF
--- a/CitiApps/SDK/communication-ui-library-ios-AzureCommunicationUICalling_1.1.0/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/Reducer/LocalUserReducer.swift
+++ b/CitiApps/SDK/communication-ui-library-ios-AzureCommunicationUICalling_1.1.0/AzureCommunicationUI/sdk/AzureCommunicationUICalling/Sources/Redux/Reducer/LocalUserReducer.swift
@@ -38,6 +38,7 @@ extension Reducer where State == LocalUserState,
             cameraStatus = .off
         case .cameraOffFailed(let error):
             cameraStatus = .error(error)
+            localVideoStreamIdentifier = nil
         case .cameraPausedSucceeded:
             cameraStatus = .paused
         case .cameraPausedFailed(let error):


### PR DESCRIPTION
13. Click on video call, when it’s in joining calling state click back arrow and close calling screen then recall as video, video doesn’t appear